### PR TITLE
feat(parser): Add test for special character parsing

### DIFF
--- a/tests/test_data/special_chars_article.xml
+++ b/tests/test_data/special_chars_article.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<articleset>
+  <article>
+    <front>
+      <journal-meta>
+        <journal-title-group>
+          <journal-title>Journal of Special Characters</journal-title>
+        </journal-title-group>
+        <publisher>
+          <publisher-name>Entity Publishing</publisher-name>
+        </publisher>
+      </journal-meta>
+      <article-meta>
+        <article-id pub-id-type="pmc">PMC_SPECIAL1</article-id>
+        <title-group>
+          <article-title>Test: "Special" Characters &amp; Entities Like &lt; &amp; &gt;'</article-title>
+        </title-group>
+        <contrib-group>
+          <contrib contrib-type="author">
+            <name>
+              <surname>Entity</surname>
+              <given-names>Anna</given-names>
+            </name>
+          </contrib>
+        </contrib-group>
+        <pub-date pub-type="epub">
+          <year>2025</year>
+        </pub-date>
+        <abstract>
+          <p>This abstract tests escaped entities like &amp; and unicode characters like α, β, &amp; γ.</p>
+        </abstract>
+        <permissions>
+            <license license-type="open-access" xlink:href="http://creativecommons.org/licenses/by/4.0/" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <p>CC BY 4.0</p>
+            </license>
+        </permissions>
+      </article-meta>
+    </front>
+    <body>
+      <p>Body text.</p>
+    </body>
+  </article>
+</articleset>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -185,3 +185,30 @@ def test_parse_jats_xml_with_different_namespace_prefix():
     assert metadata.pmcid == "PMC004"
     assert metadata.license_info is not None
     assert metadata.license_info.url == "http://creativecommons.org/licenses/by/4.0/"
+
+
+def test_parse_jats_xml_with_special_characters():
+    """
+    Tests that the parser correctly handles XML entities and unicode characters
+    in the text content of various fields.
+    """
+    xml_path = Path(__file__).parent / "test_data" / "special_chars_article.xml"
+    with open(xml_path, "rb") as f:
+        content = f.read()
+    results = list(parse_jats_xml(io.BytesIO(content)))
+
+    # Check that one article was parsed
+    assert len(results) == 1
+
+    metadata, _ = results[0]
+
+    # Check IDs
+    assert metadata.pmcid == "PMC_SPECIAL1"
+
+    # Check content with special characters
+    # The parser should decode the XML entities back to their original characters
+    expected_title = "Test: \"Special\" Characters & Entities Like < & >'"
+    assert metadata.title == expected_title
+
+    expected_abstract = "This abstract tests escaped entities like & and unicode characters like α, β, & γ."
+    assert metadata.abstract_text == expected_abstract


### PR DESCRIPTION
Adds a new unit test to verify that the JATS XML parser correctly handles articles containing special characters and XML entities in text fields.

- Creates a new test XML file with escaped entities and unicode characters.
- Adds a new test function to parse this file and assert that the title and abstract are decoded correctly.

This improves the robustness of the parser by testing its behavior against common real-world data complexities.